### PR TITLE
Fixes no unsectioned/orphaned variables' section when using custom sections

### DIFF
--- a/src/OpenLawForm.js
+++ b/src/OpenLawForm.js
@@ -120,7 +120,7 @@ const renderSectionsAndInputs = (props: RendererSectionProps) => {
   };
 
   return GetSections(variableNames, sectionVariables, sections, getSectionsConfig)
-    .map(({ variables, ...sectionData }, index) => {
+    .map(({ variables, ...sectionData }, index, { length:sectionCount }) => {
       if (renderSections) {
         const inputsChildrenComponent = () => (
           variables
@@ -131,6 +131,7 @@ const renderSectionsAndInputs = (props: RendererSectionProps) => {
         return renderSections({
           children: inputsChildrenComponent,
           ...sectionData,
+          sectionCount,
         });
       }
 

--- a/src/sectionUtil.js
+++ b/src/sectionUtil.js
@@ -30,11 +30,11 @@ export const GetSections = (
     // default
     return 'Miscellaneous';
   };
+  const { sectionTransform, sectionVariablesMap } = config;
 
   const mappedSections: Array<any> = sections
     .map((section, index) => {
-      const { sectionTransform, sectionVariablesMap } = config;
-      const sectionVariablesFromConfig = sectionVariablesMap && sectionVariablesMap(section, index);
+      const sectionVariablesFromConfig = sectionVariablesMap && sectionVariablesMap(section, index, variables);
 
       const [ userSectionKey ] = sectionVariablesFromConfig ? Object.keys(sectionVariablesFromConfig) : [];
 
@@ -63,7 +63,7 @@ export const GetSections = (
     // get rid of any `undefined` slots
     .filter(section => section && true);
 
-  const orphanVariables = (
+  const unsectionedVariables = (
     variables
       .filter(v => {
         const flattedSectionVariables = mappedSections
@@ -73,11 +73,26 @@ export const GetSections = (
       })
   );
 
-  if (orphanVariables.length > 0) {
-    mappedSections.push({
-      section: getUnsectionedTitle(),
-      variables: orphanVariables,
-    });
+  // give the unsectioned variables a home in their own section
+  if (unsectionedVariables.length) {
+    let sectionData;
+
+    // user has a desired section data shape for display purposes
+    if (sectionTransform) {
+      const index = mappedSections.length;
+
+      sectionData = {
+        ...sectionTransform(getUnsectionedTitle(), index),
+        variables: unsectionedVariables,
+      };
+    } else {
+      sectionData = {
+        section: getUnsectionedTitle(),
+        variables: unsectionedVariables,
+      };
+    }
+
+    mappedSections.push(sectionData);
   }
 
   return mappedSections;


### PR DESCRIPTION
* Fixes bug where non-sectioned variables would not get a created section, as is the default.
* Adds a `sectionCount` property to pass to `renderSections`
* Additionally, adds an argument for provided variables to `sectionVariablesMap(section, index, variables)`
