### PR TITLE
umd: propTypes no more runtime error

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -63,12 +63,11 @@ const umd = {
     format: 'umd',
     name: 'OpenLawForm',
     globals: {
-      'prop-types': 'PropTypes',
       react: 'React',
       'react-dom': 'ReactDOM',
     },
   },
-  external: ['prop-types', 'react', 'react-dom'],
+  external: ['react', 'react-dom'],
   plugins: [
     babel({
       runtimeHelpers: true,


### PR DESCRIPTION
UMD build

* Fixed a kind-of catch-22 with not needing prop-types, but having it yell at me for not having it. Fixed this in Rollup build. React recommends not including prop-types in your UMD  browser build, but in our case the alternative is a user including a CDN script tag with prop-types as a dependency.