### PR TITLE
Pure render for "variable" components

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,6 +6,7 @@
   ],
   "globals": {
     "document": true,
+    "setTimeout": true,
     "window": true
   },
   "parserOptions": {

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,4 +1,5 @@
 [ignore]
+dist
 
 [include]
 

--- a/example/index.html
+++ b/example/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>react-virtualized</title>
+    <title>OpenLaw Elements Example</title>
     <meta charset="utf-8">
     <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport" />
   </head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4048,8 +4048,7 @@
     "deep-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-      "dev": true
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
     },
     "deep-extend": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1",
+    "deep-equal": "^1.0.1",
     "flatpickr": "^4.5.2",
     "prop-types": "^15.7.2",
     "react-autosuggest": "^9.4.3",

--- a/src/Address.js
+++ b/src/Address.js
@@ -5,12 +5,14 @@ import Autosuggest from 'react-autosuggest';
 
 type Props = {
   apiClient: Object, // opt-out of type checker until we export APIClient flow types
+  cleanName: string,
+  description: string,
+  name: string,
   onChange: (string, ?string) => mixed,
   onKeyUp?: (SyntheticKeyboardEvent<HTMLInputElement>, boolean) => mixed,
   openLaw: Object, // opt-out of type checker
   savedValue: string,
   textLikeInputClass: string,
-  variable: {},
 };
 
 type State = {
@@ -23,9 +25,7 @@ type State = {
 const getSuggestionValue = suggestion => suggestion.address;
 const renderSuggestion = suggestion => <div>{suggestion.address}</div>;
 
-export class Address extends React.Component<Props, State> {
-  openLaw = this.props.openLaw;
-
+export class Address extends React.PureComponent<Props, State> {
   isDataValid = false;
 
   state = {
@@ -69,8 +69,7 @@ export class Address extends React.Component<Props, State> {
           .catch(() => { this.isDataValid = false; });
       }
     } else {
-      const variable = this.props.variable;
-      const name = this.openLaw.getName(variable);
+      const { name } = this.props;
 
       this.setState({
         currentValue: eventValue,
@@ -103,30 +102,30 @@ export class Address extends React.Component<Props, State> {
 
   submitAddress(address: Object): Promise<any> {
     return new Promise((resolve, reject) => {
-      const variable = this.props.variable;
+      const { name, openLaw } = this.props;
 
       try {
-        if (variable) {
+        if (address) {
           this.setState({
             validationError: false,
             currentValue: address.address,
           }, () => {
-            this.props.onChange(this.openLaw.getName(variable), this.openLaw.createAddress(address));
+            this.props.onChange(name, openLaw.createAddress(address));
 
             resolve();
           });
         } else {
           this.setState({
-            validationError: false,
             currentValue: undefined,
+            validationError: false,
           }, () => {
-            this.props.onChange(this.openLaw.getName(variable));
+            this.props.onChange(name);
           });
         }
       } catch (error) {
         this.setState({
-          validationError: true,
           currentValue: '',
+          validationError: true,
         });
 
         reject();
@@ -135,9 +134,7 @@ export class Address extends React.Component<Props, State> {
   }
 
   render() {
-    const variable = this.props.variable;
-    const cleanName = this.openLaw.getCleanName(variable);
-    const description = this.openLaw.getDescription(variable);
+    const { description, cleanName } = this.props;
     const additionalClassName = this.state.validationError ? ' is-error' : '';
 
     const inputProps = {

--- a/src/Choice.js
+++ b/src/Choice.js
@@ -6,7 +6,7 @@ type Props = {
   choiceValues: Array<string>,
   cleanName: string,
   description: string,
-  getValidity: (string) => string | false,
+  getValidity: (string, string) => any | false,
   name: string,
   onChange: (string, ?string) => mixed,
   savedValue: string,
@@ -55,7 +55,7 @@ export class Choice extends React.PureComponent<Props, State> {
       return;
     }
 
-    if (getValidity(eventValue)) {
+    if (getValidity(name, eventValue)) {
       this.setState({
         currentValue: eventValue,
         validationError: false,

--- a/src/DatePicker.js
+++ b/src/DatePicker.js
@@ -38,7 +38,7 @@ export class DatePicker extends React.PureComponent<Props, State> {
   }
 
   componentDidMount() {
-    const { name } = this.props;
+    const { cleanName } = this.props;
     let options = {};
 
     // display in a friendly format (e.g. January, 1, 1971)
@@ -50,7 +50,7 @@ export class DatePicker extends React.PureComponent<Props, State> {
 
     if (this.props.textLikeInputClass) {
       // Flatpickr inherits our classnames from the original input element
-      options.altInputClass = `${this.props.textLikeInputClass} ${name}`;
+      options.altInputClass = `${this.props.textLikeInputClass} ${cleanName}`;
     }
 
     if (this.props.savedValue) {

--- a/src/DatePicker.js
+++ b/src/DatePicker.js
@@ -5,23 +5,22 @@ import flatpickr from 'flatpickr';
 import 'flatpickr/dist/flatpickr.css';
 
 type Props = {
+  cleanName: string,
+  description: string,
   enableTime: boolean,
+  name: string,
   onChange: (string, ?string) => mixed,
-  openLaw: Object, // opt-out of type checker
   savedValue: string,
   textLikeInputClass: string,
-  variable: {},
 };
 
 type State = {
   enableTime: boolean,
 };
 
-export class DatePicker extends React.Component<Props, State> {
+export class DatePicker extends React.PureComponent<Props, State> {
   id: string;
   flatpickr: flatpickr;
-
-  openLaw = this.props.openLaw;
 
   state = {
     enableTime: this.props.enableTime,
@@ -30,7 +29,7 @@ export class DatePicker extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
 
-    const cleanName = this.openLaw.getCleanName(this.props.variable);
+    const { cleanName } = this.props;
     const timestamp = new Date().getTime().toString();
     this.id = this.id || `date_${cleanName}_${timestamp}`;
 
@@ -39,6 +38,7 @@ export class DatePicker extends React.Component<Props, State> {
   }
 
   componentDidMount() {
+    const { name } = this.props;
     let options = {};
 
     // display in a friendly format (e.g. January, 1, 1971)
@@ -50,7 +50,7 @@ export class DatePicker extends React.Component<Props, State> {
 
     if (this.props.textLikeInputClass) {
       // Flatpickr inherits our classnames from the original input element
-      options.altInputClass = `${this.props.textLikeInputClass} ${this.openLaw.getCleanName(this.props.variable)}`;
+      options.altInputClass = `${this.props.textLikeInputClass} ${name}`;
     }
 
     if (this.props.savedValue) {
@@ -73,16 +73,14 @@ export class DatePicker extends React.Component<Props, State> {
   }
 
   onChange(selectedDates: Array<any>) {
-    const variable = this.props.variable;
-    const name = this.openLaw.getName(variable);
+    const { description, name } = this.props;
     const epochUTCString = (selectedDates.length ? selectedDates[0].getTime().toString() : undefined);
 
     this.props.onChange(name, epochUTCString);
   }
 
   render() {
-    const variable = this.props.variable;
-    const description = this.openLaw.getDescription(variable);
+    const { description } = this.props;
 
     return (
       <div className="contract-variable">

--- a/src/DatePicker.js
+++ b/src/DatePicker.js
@@ -73,7 +73,7 @@ export class DatePicker extends React.PureComponent<Props, State> {
   }
 
   onChange(selectedDates: Array<any>) {
-    const { description, name } = this.props;
+    const { name } = this.props;
     const epochUTCString = (selectedDates.length ? selectedDates[0].getTime().toString() : undefined);
 
     this.props.onChange(name, epochUTCString);

--- a/src/Identity.js
+++ b/src/Identity.js
@@ -40,18 +40,23 @@ export class Identity extends React.PureComponent<Props, State> {
   componentDidMount() {
     const { getValidity, openLaw, savedValue } = this.props;
 
-    const identity = getValidity(savedValue);
+    try {
+      if (this.props.savedValue) {
+        const identity = getValidity(savedValue);
 
-    if (savedValue && identity) {
+        this.setState({
+          email: openLaw.getIdentityEmail(identity),
+        });
+      } else {
+        this.setState({
+          email: '',
+        });
+      }
+    } catch (error) {
       this.setState({
-        email: openLaw.getIdentityEmail(identity),
+        email: '',
       });
-
-      // exit
-      return;
     }
-
-    this.setState({ email: '' });
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -59,15 +64,16 @@ export class Identity extends React.PureComponent<Props, State> {
 
     if (
       !this.state.validationError
-      && (this.props.savedValue !== prevProps.savedValue)
+      && (savedValue !== prevProps.savedValue)
     ) {
-      const identity = getValidity(this.props.savedValue);
+      try {
+        const identity = getValidity(savedValue);
 
-      if (identity) {
         this.setState({
           email: openLaw.getIdentityEmail(identity) || '',
         });
-      } else {
+      }
+      catch (error) {
         this.setState({
           email: '',
           validationError: true,

--- a/src/Identity.js
+++ b/src/Identity.js
@@ -134,7 +134,7 @@ export class Identity extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const { cleanName, description, name } = this.props;
+    const { cleanName, description } = this.props;
     const additionalClassName = this.state.validationError ? ' is-error' : '';
 
     return (

--- a/src/Identity.js
+++ b/src/Identity.js
@@ -6,7 +6,7 @@ type Props = {
   apiClient: Object, // opt-out of type checker until Flow types are exported for APIClient
   cleanName: string,
   description: string,
-  getValidity: (string) => string | false,
+  getValidity: (string, string) => any | false,
   name: string,
   onChange: (string, ?string) => mixed,
   onKeyUp?: (SyntheticKeyboardEvent<HTMLInputElement>, boolean) => mixed,
@@ -38,11 +38,11 @@ export class Identity extends React.PureComponent<Props, State> {
   }
 
   componentDidMount() {
-    const { getValidity, openLaw, savedValue } = this.props;
+    const { getValidity, name, openLaw, savedValue } = this.props;
 
     try {
       if (this.props.savedValue) {
-        const identity = getValidity(savedValue);
+        const identity = getValidity(name, savedValue);
 
         this.setState({
           email: openLaw.getIdentityEmail(identity),
@@ -60,14 +60,14 @@ export class Identity extends React.PureComponent<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    const { getValidity, openLaw, savedValue } = this.props;
+    const { getValidity, name, openLaw, savedValue } = this.props;
 
     if (
       !this.state.validationError
       && (savedValue !== prevProps.savedValue)
     ) {
       try {
-        const identity = getValidity(savedValue);
+        const identity = getValidity(name, savedValue);
 
         this.setState({
           email: openLaw.getIdentityEmail(identity) || '',

--- a/src/ImageInput.js
+++ b/src/ImageInput.js
@@ -7,7 +7,7 @@ import ImageCrop from './ImageCrop';
 type Props = {
   cleanName: string,
   description: string,
-  getValidity: (string) => string | false,
+  getValidity: (string, string) => string | false,
   name: string,
   onChange: (string, string) => mixed,
   savedValue: string,
@@ -256,9 +256,10 @@ export class ImageInput extends React.PureComponent<Props, State> {
       resizedImageDataURL = '';
     }
 
-    const validity = getValidity(resizedImageDataURL);
-    // if string either has length, or is empty, it's valid
-    const isImageDataValid = (validity && validity.length > 0) || (validity && validity.length === 0);
+    const validity = getValidity(name, resizedImageDataURL);
+
+    // if the valid string either has length, or is empty, it's valid
+    const isImageDataValid = (validity && validity.length > 0) || (validity === '' && validity.length === 0);
 
     if (isImageDataValid) {
       if (resizedImageDataURL) {

--- a/src/ImageInput.js
+++ b/src/ImageInput.js
@@ -280,7 +280,7 @@ export class ImageInput extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const { cleanName, description, name } = this.props;
+    const { cleanName, description } = this.props;
     const { disableEditRemoteImage } = this.state;
 
     /* eslint-disable complexity */

--- a/src/InputRenderer.js
+++ b/src/InputRenderer.js
@@ -28,7 +28,6 @@ type RendererProps = {
 // keep React rendering happy with the same Array reference, if not changed.
 const getChoiceValuesCached = cacheValue(deepEqual);
 const variableCache = {};
-let onChangeForceFunctionCached;
 let executionResultCached;
 let openLawCached;
 
@@ -45,15 +44,6 @@ const getVariableData = (variable: {}, openLaw: Object) => ({
   description: openLaw.getDescription(variable),
   name: openLaw.getName(variable),
 });
-
-// TODO refactor; `force = true` is specific to the OpenLaw web app
-const onChangeFunctionForce = (onChangeFunction) => {
-  if (!onChangeForceFunctionCached) {
-    onChangeForceFunctionCached = (key, value) => onChangeFunction(key, value, true);
-  }
-
-  return onChangeForceFunctionCached;
-};
 
 export const InputRenderer = (props: RendererProps) => {
   const {
@@ -204,10 +194,7 @@ export const InputRenderer = (props: RendererProps) => {
           cleanName={cleanName}
           description={description}
           name={name}
-          // uses a param `force` set to `true`
-          // TODO re-evaluate overriding onChange from the top-level
-          // as we really only use this function in OpenLaw's front-end to tell Redux something.
-          onChange={onChangeFunctionForce(onChangeFunction)}
+          onChange={onChangeFunction}
           savedValue={savedValue}
         />
       );

--- a/src/InputRenderer.js
+++ b/src/InputRenderer.js
@@ -60,7 +60,7 @@ const onChangeFunctionForce = (onChangeFunction) => {
   }
 
   return onChangeForceFunctionCached;
-}
+};
 
 export const InputRenderer = (props: RendererProps) => {
   const {

--- a/src/InputRenderer.js
+++ b/src/InputRenderer.js
@@ -1,6 +1,7 @@
 // @flow
 
 import * as React from 'react';
+import deepEqual from 'deep-equal';
 
 import { Address } from './Address';
 import { Choice } from './Choice';
@@ -11,6 +12,7 @@ import { LargeText } from './LargeText';
 import { NumberInput } from './NumberInput';
 import { Text } from './Text';
 import { YesNo } from './YesNo';
+import { cacheValue } from './utils';
 
 type RendererProps = {
   apiClient: Object, // opt-out of type checker until we export its Flow types
@@ -22,6 +24,43 @@ type RendererProps = {
   textLikeInputClass: string,
   variable: {},
 };
+
+// keep React rendering happy with the same Array reference, if not changed.
+const getChoiceValuesCached = cacheValue(deepEqual);
+let getValidityFunctionCached;
+let onChangeForceFunctionCached;
+
+const attemptCheckValidity = (variable, value, executionResult, openLaw) => {
+  try {
+    return openLaw.checkValidity(variable, value, executionResult);
+  } catch (error) {
+    return false;
+  }
+};
+
+const getVariableData = (variable: {}, openLaw: Object) => ({
+  cleanName: openLaw.getCleanName(variable),
+  description: openLaw.getDescription(variable),
+  getValidity: (variable: {}, executionResult: {}) => {
+    if (!getValidityFunctionCached) {
+      getValidityFunctionCached = (value) => (
+        attemptCheckValidity(variable, value, executionResult, openLaw)
+      );
+    }
+
+    return getValidityFunctionCached;
+  },
+  name: openLaw.getName(variable),
+});
+
+// TODO refactor; `force = true` is specific to the OpenLaw web app
+const onChangeFunctionForce = (onChangeFunction) => {
+  if (!onChangeForceFunctionCached) {
+    onChangeForceFunctionCached = (key, value) => onChangeFunction(key, value, true);
+  }
+
+  return onChangeForceFunctionCached;
+}
 
 export const InputRenderer = (props: RendererProps) => {
   const {
@@ -35,19 +74,27 @@ export const InputRenderer = (props: RendererProps) => {
     variable,
   } = props;
 
-  // TODO refactor; `force = true` is specific to the OpenLaw apps
-  const onChangeFunctionForce = (key, value) => onChangeFunction(key, value, true);
+  const {
+    cleanName,
+    description,
+    getValidity,
+    name,
+  } = getVariableData(variable, openLaw);
 
   // Choice type detection is different
   if (openLaw.isChoiceType(variable, executionResult)) {
+    const choiceValues = getChoiceValuesCached(openLaw.getChoiceValues(variable, executionResult));
+
     return (
       <Choice
-        executionResult={executionResult}
+        choiceValues={choiceValues}
+        cleanName={cleanName}
+        description={description}
+        getValidity={getValidity(variable, executionResult)}
+        name={name}
         onChange={onChangeFunction}
-        openLaw={openLaw}
         savedValue={savedValue}
         textLikeInputClass={textLikeInputClass}
-        variable={variable}
       />
     );
   }
@@ -57,6 +104,9 @@ export const InputRenderer = (props: RendererProps) => {
       return (
         <Address
           apiClient={apiClient} // for API call to Google for geo data
+          cleanName={cleanName}
+          description={description}
+          name={name}
           onChange={onChangeFunction}
           onKeyUp={onKeyUp}
           openLaw={openLaw}
@@ -66,31 +116,32 @@ export const InputRenderer = (props: RendererProps) => {
               : ''
           }
           textLikeInputClass={textLikeInputClass}
-          variable={variable}
         />
       );
 
     case 'Date':
       return (
         <DatePicker
+          cleanName={cleanName}
+          description={description}
           enableTime={false}
+          name={name}
           onChange={onChangeFunction}
-          openLaw={openLaw}
           savedValue={savedValue}
           textLikeInputClass={textLikeInputClass}
-          variable={variable}
         />
       );
 
     case 'DateTime':
       return (
         <DatePicker
+          cleanName={cleanName}
+          description={description}
           enableTime
+          name={name}
           onChange={onChangeFunction}
-          openLaw={openLaw}
           savedValue={savedValue}
           textLikeInputClass={textLikeInputClass}
-          variable={variable}
         />
       );
 
@@ -98,75 +149,81 @@ export const InputRenderer = (props: RendererProps) => {
       return (
         <Identity
           apiClient={apiClient}
-          executionResult={executionResult}
+          cleanName={cleanName}
+          description={description}
+          getValidity={getValidity(variable, executionResult)}
+          name={name}
           onChange={onChangeFunction}
           onKeyUp={onKeyUp}
           openLaw={openLaw}
           savedValue={savedValue}
           textLikeInputClass={textLikeInputClass}
-          variable={variable}
         />
       );
 
     case 'Image':
       return (
         <ImageInput
-          executionResult={executionResult}
+          cleanName={cleanName}
+          description={description}
+          getValidity={getValidity(variable, executionResult)}
+          name={name}
           onChange={onChangeFunction}
-          openLaw={openLaw}
           savedValue={savedValue}
-          variable={variable}
         />
       );
 
     case 'LargeText':
       return (
         <LargeText
-          executionResult={executionResult}
+          cleanName={cleanName}
+          description={description}
+          name={name}
           onChange={onChangeFunction}
-          openLaw={openLaw}
           savedValue={savedValue}
           textLikeInputClass={textLikeInputClass}
-          variable={variable}
         />
       );
 
     case 'Number':
       return (
         <NumberInput
-          executionResult={executionResult}
+          cleanName={cleanName}
+          description={description}
+          getValidity={getValidity(variable, executionResult)}
+          name={name}
           onChange={onChangeFunction}
           onKeyUp={onKeyUp}
-          openLaw={openLaw}
           savedValue={savedValue}
           textLikeInputClass={textLikeInputClass}
-          variable={variable}
         />
       );
 
     case 'YesNo':
       return (
         <YesNo
+          cleanName={cleanName}
+          description={description}
+          name={name}
           // uses a param `force` set to `true`
           // TODO re-evaluate overriding onChange from the top-level
           // as we really only use this function in OpenLaw's front-end to tell Redux something.
-          onChange={onChangeFunctionForce}
-          openLaw={openLaw}
+          onChange={onChangeFunctionForce(onChangeFunction)}
           savedValue={savedValue}
-          variable={variable}
         />
       );
 
     default:
       return (
         <Text
-          executionResult={executionResult}
+          cleanName={cleanName}
+          description={description}
+          getValidity={getValidity(variable, executionResult)}
+          name={name}
           onChange={onChangeFunction}
           onKeyUp={onKeyUp}
-          openLaw={openLaw}
           savedValue={savedValue}
           textLikeInputClass={textLikeInputClass}
-          variable={variable}
         />
       );
   }

--- a/src/InputRenderer.js
+++ b/src/InputRenderer.js
@@ -76,7 +76,7 @@ export const InputRenderer = (props: RendererProps) => {
   // store latest executionResult for access outside React
   executionResultCached = executionResult;
   // store openLaw for access outside React
-  openLawCached = openLaw;
+  if (!openLawCached) openLawCached = openLaw;
   // store { [name]: variable } for access outside React
   variableCache[name] = variable;
 

--- a/src/InputRenderer.js
+++ b/src/InputRenderer.js
@@ -28,7 +28,6 @@ type RendererProps = {
 // keep React rendering happy with the same Array reference, if not changed.
 const getChoiceValuesCached = cacheValue(deepEqual);
 const variableCache = {};
-let getValidityFunctionCached;
 let onChangeForceFunctionCached;
 let executionResultCached;
 let openLawCached;

--- a/src/LargeText.js
+++ b/src/LargeText.js
@@ -3,12 +3,12 @@
 import * as React from 'react';
 
 type Props = {
-  executionResult: {},
+  cleanName: string,
+  description: string,
+  name: string,
   onChange: (string, ?string) => mixed,
-  openLaw: Object, // opt-out of type checker
   savedValue: string,
   textLikeInputClass: string,
-  variable: {},
 };
 
 type State = {
@@ -16,9 +16,7 @@ type State = {
   validationError: boolean,
 };
 
-export class LargeText extends React.Component<Props, State> {
-  openLaw = this.props.openLaw;
-
+export class LargeText extends React.PureComponent<Props, State> {
   state = {
     currentValue: this.props.savedValue || '',
     validationError: false,
@@ -43,43 +41,30 @@ export class LargeText extends React.Component<Props, State> {
   }
 
   onChange(event: SyntheticEvent<*>) {
-    const variable = this.props.variable;
     const eventValue = event.currentTarget.value;
+    const { name } = this.props;
 
-    try {
-      const name = this.openLaw.getName(variable);
-
-      if (eventValue) {
-        this.openLaw.checkValidity(variable, eventValue, this.props.executionResult);
-
-        this.setState({
-          validationError: false,
-          currentValue: eventValue,
-        }, () => {
-          this.props.onChange(name, eventValue);
-        });
-      } else {
-        if (this.state.currentValue) {
-          this.setState({
-            validationError: false,
-            currentValue: '',
-          }, () => {
-            this.props.onChange(name);
-          });
-        }
-      }
-    } catch (error) {
+    if (eventValue) {
       this.setState({
         currentValue: eventValue,
-        validationError: true,
+        validationError: false,
+      }, () => {
+        this.props.onChange(name, eventValue);
       });
+    } else {
+      if (this.state.currentValue) {
+        this.setState({
+          currentValue: '',
+          validationError: false,
+        }, () => {
+          this.props.onChange(name);
+        });
+      }
     }
   }
 
   render() {
-    const variable = this.props.variable;
-    const cleanName = this.openLaw.getCleanName(variable);
-    const description = this.openLaw.getDescription(variable);
+    const { cleanName, description } = this.props;
     const additionalClassName = this.state.validationError ? ' is-error' : '';
 
     return (

--- a/src/NumberInput.js
+++ b/src/NumberInput.js
@@ -5,7 +5,7 @@ import * as React from 'react';
 type Props = {
   cleanName: string,
   description: string,
-  getValidity: (string) => Object | false, // string for valid; throws Object for error (not valid)
+  getValidity: (string, string) => any | false,
   name: string,
   onChange: (string, ?string) => mixed,
   onKeyUp?: (SyntheticKeyboardEvent<HTMLInputElement>) => mixed,
@@ -55,7 +55,7 @@ export class NumberInput extends React.PureComponent<Props, State> {
       return;
     }
 
-    if (getValidity(eventValue)) {
+    if (getValidity(name, eventValue)) {
       this.setState({
         currentValue: eventValue,
         validationError: false,

--- a/src/NumberInput.js
+++ b/src/NumberInput.js
@@ -3,13 +3,14 @@
 import * as React from 'react';
 
 type Props = {
-  executionResult: {},
+  cleanName: string,
+  description: string,
+  getValidity: (string) => Object | false, // string for valid; throws Object for error (not valid)
+  name: string,
   onChange: (string, ?string) => mixed,
   onKeyUp?: (SyntheticKeyboardEvent<HTMLInputElement>) => mixed,
-  openLaw: Object, // opt-out of type checker
   savedValue: string,
   textLikeInputClass: string,
-  variable: {},
 };
 
 type State = {
@@ -17,9 +18,7 @@ type State = {
   validationError: boolean,
 };
 
-export class NumberInput extends React.Component<Props, State> {
-  openLaw = this.props.openLaw;
-
+export class NumberInput extends React.PureComponent<Props, State> {
   state = {
     currentValue: this.props.savedValue || '',
     validationError: false,
@@ -41,32 +40,29 @@ export class NumberInput extends React.Component<Props, State> {
   }
 
   onChange(event: SyntheticEvent<HTMLInputElement>) {
-    const variable = this.props.variable;
     const eventValue = event.currentTarget.value;
+    const { getValidity, name } = this.props;
 
-    try {
-      if (eventValue) {
-        this.openLaw.checkValidity(
-          variable,
-          eventValue,
-          this.props.executionResult,
-        );
+    if (!eventValue) {
+      this.setState({
+        currentValue: '',
+        validationError: false,
+      }, () => {
+        this.props.onChange(name);
+      });
 
-        this.setState({
-          currentValue: eventValue,
-          validationError: false,
-        }, () => {
-          this.props.onChange(this.openLaw.getName(variable), eventValue);
-        });
-      } else {
-        this.setState({
-          currentValue: '',
-          validationError: false,
-        }, () => {
-          this.props.onChange(this.openLaw.getName(variable));
-        });
-      }
-    } catch (error) {
+      // exit
+      return;
+    }
+
+    if (getValidity(eventValue)) {
+      this.setState({
+        currentValue: eventValue,
+        validationError: false,
+      }, () => {
+        this.props.onChange(name, eventValue);
+      });
+    } else {
       this.setState({
         currentValue: eventValue,
         validationError: true,
@@ -75,9 +71,7 @@ export class NumberInput extends React.Component<Props, State> {
   }
 
   render() {
-    const variable = this.props.variable;
-    const cleanName = this.openLaw.getCleanName(variable);
-    const description = this.openLaw.getDescription(variable);
+    const { cleanName, description } = this.props;
 
     return (
       <div className="contract-variable">

--- a/src/Text.js
+++ b/src/Text.js
@@ -5,7 +5,7 @@ import * as React from 'react';
 type Props = {
   cleanName: string,
   description: string,
-  getValidity: (string) => string | false,
+  getValidity: (string, string) => any | false,
   name: string,
   onChange: (string, ?string) => mixed,
   onKeyUp?: (SyntheticKeyboardEvent<HTMLInputElement>) => mixed,
@@ -60,7 +60,7 @@ export class Text extends React.PureComponent<Props, State> {
       return;
     }
 
-    if (getValidity(eventValue)) {
+    if (getValidity(name, eventValue)) {
       this.setState({
         currentValue: eventValue,
         validationError: false,

--- a/src/Text.js
+++ b/src/Text.js
@@ -3,13 +3,14 @@
 import * as React from 'react';
 
 type Props = {
-  executionResult: {},
+  cleanName: string,
+  description: string,
+  getValidity: (string) => string | false,
+  name: string,
   onChange: (string, ?string) => mixed,
   onKeyUp?: (SyntheticKeyboardEvent<HTMLInputElement>) => mixed,
-  openLaw: Object, // opt-out of type checker
   savedValue: string,
   textLikeInputClass: string,
-  variable: {},
 };
 
 type State = {
@@ -17,9 +18,7 @@ type State = {
   validationError: boolean,
 };
 
-export class Text extends React.Component<Props, State> {
-  openLaw = this.props.openLaw;
-
+export class Text extends React.PureComponent<Props, State> {
   state = {
     currentValue: this.props.savedValue || '',
     validationError: false,
@@ -44,32 +43,31 @@ export class Text extends React.Component<Props, State> {
   }
 
   onChange(event: SyntheticEvent<HTMLInputElement>) {
-    const variable = this.props.variable;
     const eventValue = event.currentTarget.value;
+    const { getValidity, name } = this.props;
 
-    try {
-      const name = this.openLaw.getName(variable);
-
-      if (eventValue) {
-        this.openLaw.checkValidity(variable, eventValue, this.props.executionResult);
-
+    if (!eventValue) {
+      if (this.state.currentValue) {
         this.setState({
-          currentValue: eventValue,
+          currentValue: '',
           validationError: false,
         }, () => {
-          this.props.onChange(name, eventValue);
+          this.props.onChange(name);
         });
-      } else {
-        if (this.state.currentValue) {
-          this.setState({
-            currentValue: '',
-            validationError: false,
-          }, () => {
-            this.props.onChange(name);
-          });
-        }
       }
-    } catch (error) {
+
+      // exit
+      return;
+    }
+
+    if (getValidity(eventValue)) {
+      this.setState({
+        currentValue: eventValue,
+        validationError: false,
+      }, () => {
+        this.props.onChange(name, eventValue);
+      });
+    } else {
       this.setState({
         currentValue: eventValue,
         validationError: true,
@@ -78,9 +76,7 @@ export class Text extends React.Component<Props, State> {
   }
 
   render() {
-    const variable = this.props.variable;
-    const cleanName = this.openLaw.getCleanName(variable);
-    const description = this.openLaw.getDescription(variable);
+    const { cleanName, description } = this.props;
     const additionalClassName = this.state.validationError ? ' is-error' : '';
 
     return (

--- a/src/YesNo.js
+++ b/src/YesNo.js
@@ -46,7 +46,7 @@ export class YesNo extends React.PureComponent<Props, State> {
 
   onChange(event: SyntheticEvent<HTMLInputElement>) {
     const eventValue = event.currentTarget.value;
-    const { name, savedValue } = this.props;
+    const { name } = this.props;
 
     this.setState({
       currentValue: eventValue,
@@ -68,7 +68,7 @@ export class YesNo extends React.PureComponent<Props, State> {
     if (currentNoRef && currentYesRef && this.props.savedValue === 'false') {
       currentNoRef.checked = true;
     }
-  };
+  }
 
   render() {
     const { cleanName, description } = this.props;

--- a/src/YesNo.js
+++ b/src/YesNo.js
@@ -3,19 +3,18 @@
 import * as React from 'react';
 
 type Props = {
+  cleanName: string,
+  description: string,
+  name: string,
   onChange: (string, string) => mixed,
-  openLaw: Object, // opt-out of type checker
   savedValue: string,
-  variable: {},
 };
 
 type State = {
   currentValue: string,
 };
 
-export class YesNo extends React.Component<Props, State> {
-  openLaw = this.props.openLaw;
-
+export class YesNo extends React.PureComponent<Props, State> {
   state = {
     currentValue: this.props.savedValue,
   };
@@ -28,7 +27,7 @@ export class YesNo extends React.Component<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    if (this.props.savedValue !== prevProps.savedValue) {
+    if (prevProps.savedValue !== this.props.savedValue) {
       this.setState({
         currentValue: this.props.savedValue,
       });
@@ -36,9 +35,8 @@ export class YesNo extends React.Component<Props, State> {
   }
 
   onChange(event: SyntheticEvent<HTMLInputElement>) {
-    const variable = this.props.variable;
-    const name = this.openLaw.getName(variable);
     const eventValue = event.currentTarget.value;
+    const { name } = this.props;
 
     this.setState({
       currentValue: eventValue,
@@ -48,9 +46,7 @@ export class YesNo extends React.Component<Props, State> {
   }
 
   render() {
-    const variable = this.props.variable;
-    const description = this.openLaw.getDescription(variable);
-    const cleanName = this.openLaw.getCleanName(variable);
+    const { cleanName, description } = this.props;
     const additionalClass = this.state.currentValue ? ' conditional-set' : '';
 
     return (

--- a/src/YesNo.js
+++ b/src/YesNo.js
@@ -19,11 +19,21 @@ export class YesNo extends React.PureComponent<Props, State> {
     currentValue: this.props.savedValue,
   };
 
+  noRef: {current: null | HTMLInputElement} = React.createRef();
+  yesRef: {current: null | HTMLInputElement} = React.createRef();
+
   constructor(props: Props) {
     super(props);
 
     const self: any = this;
     self.onChange = this.onChange.bind(this);
+  }
+
+  componentDidMount() {
+    // This solves a timing issue where some uses of OpenLawForm
+    // were not replacing the savedValue value on mount.
+    // It only happens when using a PureComponent.
+    setTimeout(() => this.radioCheckedByRef(), 0);
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -36,7 +46,7 @@ export class YesNo extends React.PureComponent<Props, State> {
 
   onChange(event: SyntheticEvent<HTMLInputElement>) {
     const eventValue = event.currentTarget.value;
-    const { name } = this.props;
+    const { name, savedValue } = this.props;
 
     this.setState({
       currentValue: eventValue,
@@ -46,6 +56,19 @@ export class YesNo extends React.PureComponent<Props, State> {
       this.props.onChange(name, eventValue, true);
     });
   }
+
+  // visually update the uncontrolled HTML radio, as we already have the value
+  radioCheckedByRef() {
+    const currentYesRef = this.yesRef.current;
+    const currentNoRef = this.noRef.current;
+    
+    if (currentYesRef && currentNoRef && this.props.savedValue === 'true') {
+      currentYesRef.checked = true;
+    }
+    if (currentNoRef && currentYesRef && this.props.savedValue === 'false') {
+      currentNoRef.checked = true;
+    }
+  };
 
   render() {
     const { cleanName, description } = this.props;
@@ -63,9 +86,9 @@ export class YesNo extends React.PureComponent<Props, State> {
               className={cleanName}
               onChange={this.onChange}
               name={cleanName}
+              ref={this.yesRef}
               type="radio"
               value="true"
-              checked={this.state.currentValue === 'true'}
             />
             <span>Yes</span>
           </label>
@@ -75,9 +98,9 @@ export class YesNo extends React.PureComponent<Props, State> {
               className={cleanName}
               name={cleanName}
               onChange={this.onChange}
+              ref={this.noRef}
               type="radio"
               value="false"
-              checked={this.state.currentValue === 'false'}
             />
             <span>No</span>
           </label>

--- a/src/YesNo.js
+++ b/src/YesNo.js
@@ -6,7 +6,7 @@ type Props = {
   cleanName: string,
   description: string,
   name: string,
-  onChange: (string, string) => mixed,
+  onChange: (string, string, boolean) => mixed,
   savedValue: string,
 };
 
@@ -41,7 +41,9 @@ export class YesNo extends React.PureComponent<Props, State> {
     this.setState({
       currentValue: eventValue,
     }, () => {
-      this.props.onChange(name, eventValue);
+      // uses an added param `force` set to `true`
+      // TODO change should be in openlaw app, not here!
+      this.props.onChange(name, eventValue, true);
     });
   }
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,21 @@
+// @flow
+
+/**
+* cacheValue
+*
+* A simple, half-implementation of a memoization function.
+* We disregard the inputs needing to be the same. In our case
+* the objects from Openlaw methods always will cause the arguments to change.
+* 
+* @param isEqualFn<(any, any) => boolean> Any function that can compare two things and return a boolean.
+* @returns <any> Any value, cached, or new.
+*/
+export const cacheValue = (isEqualFn: (any, any) => boolean) => {
+  let cachedValue: any;
+  return (value: any) => {
+    if (isEqualFn && isEqualFn(cachedValue, value)) return cachedValue;
+
+    cachedValue = value;
+    return value;
+  };
+};


### PR DESCRIPTION
This is the base part of work to get `OpenLawForm` on large agreements to be performant. In my testing this does alleviate some performance issues with the large agreements (e.g. LSTA)! There is more work to be done in our app, specifically, but that's not really the business of this PR.

**Work done**

- Moves the calculation of Openlaw-specific props up a level to `InputRenderer`
- `executionResult` and `variable` are removed as prop dependencies, because they cannot be compared in order to _not_ render, because they are always new objects.
- Any props that can be cached, or made to be easily compared, is completed.
- All variable components are now `React.PureComponent`s

@jdville03 Can you give this a test-run in the openlaw web app, or the example app, to make sure I haven't damaged anything? In addition to my own testing, I've run `npm test` and `sbt test` (the sbt tests that are failing for sbt aren't b/c of this) on the openlaw app side with these components.

Note: If you're testing in openlaw web app, after using `yarn link`, you'll probably have to uncomment `flow` before building, otherwise there will be some incorrect flow errors.