### PR TITLE
openlaw dev bump; README change; example app auth warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,13 @@ If you'd like to load the styles via an HTML file, you can copy the path (or fil
 
 If you want to leave out our styles, that's completely OK. We've set up our components with simple classnames so you can target what you need to, easily. Just add your own stylesheet and take a look at what classes and elements you can style. We find the simplest way to prototype can be using browser developer tools.
 
-## Optional Parameters
+### Optional Parameters
 
 In addition to the required parameters, we offer support for additional parameters that will give you more flexibility to apply styles and render custom form sections. You can check out our [OpenLaw Elements docs](https://docs.openlaw.io/openlaw-elements/) for more details.
+
+### OpenLaw dependency
+
+As OpenLaw Elements depends on the [openlaw](https://www.npmjs.com/package/openlaw) package, we recommend always using the [latest](https://www.npmjs.com/package/openlaw/v/latest) version.
 
 ## Running the example app
 
@@ -107,7 +111,11 @@ If you would like to use our Address or input type, please authenticate by sendi
 OPENLAW_EMAIL=alex@email.com OPENLAW_PASSWORD=password npm start
 ```
 
-*NOTE:* If you do not provide credentials, the app will still run, but you will not be able to select an address lookup from the drop-down, nor be able to see the values in the rendered preview HTML.
+*NOTE:* If you do not provide credentials the app will still run, but you will not be able to:
+
+* Select an Address lookup from the drop-down
+* Use the Identity lookup
+* See those values in the rendered preview HTML
 
 ### About the app
 

--- a/example/index.html
+++ b/example/index.html
@@ -4,8 +4,16 @@
     <title>OpenLaw Elements Example</title>
     <meta charset="utf-8">
     <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport" />
+  	<style type="text/css">
+  		.banner {
+		    color: grey;
+		    font-family: sans-serif;
+		    padding: 16px 0;
+  		}
+  	</style>
   </head>
   <body>
+  	<div class="banner"><%= htmlWebpackPlugin.options.warningApiClient %></div>
     <div id="root"></div>
   </body>
 </html>

--- a/example/index.js
+++ b/example/index.js
@@ -29,7 +29,7 @@ apiClient
   .login(loginDetails.email, loginDetails.password) //eslint-disable-line  no-undef
   .catch((error) => {
     if (/500/.test(error)) {
-      console.warn('OpenLaw APIClient: Please authenticate to the APIClient to use the Address input.');
+      console.warn('OpenLaw APIClient: Please authenticate to the APIClient if you wish to use the Address or Identity inputs.');
       return;
     }
     console.error('OpenLaw APIClient:', error);
@@ -173,7 +173,6 @@ const styles = {
     padding: '12px 24px',
     position: 'fixed',
     right: 0,
-    top: 0,
   },
   pre: {
     wordBreak: 'break-all',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9274,9 +9274,9 @@
       }
     },
     "openlaw": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/openlaw/-/openlaw-0.1.19.tgz",
-      "integrity": "sha512-BQIcjtceRh1tj6l+WWR7V9r7YIuOQtVdBh87lYxPaiZIY94GGLfYeYbR0naa+j2jb5UTy4jDMfuBHMYVydiefw==",
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/openlaw/-/openlaw-0.1.22.tgz",
+      "integrity": "sha512-1/J2GXVGUnjZ/Tn+n1E/leawbj/35ywDcinY/W6MzToN6+SJaJGcAVuCQSF95NwXK4IoSf4xPgxJJ2jMANQAaA==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.2.0",
@@ -10413,9 +10413,9 @@
       "dev": true
     },
     "query-string": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.2.0.tgz",
-      "integrity": "sha512-5wupExkIt8RYL4h/FE+WTg3JHk62e6fFPWtAZA9J5IWK1PfTfKkMS93HBUHcFpeYi9KsY5pFbh+ldvEyaz5MyA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.4.0.tgz",
+      "integrity": "sha512-Werid2I41/tJTqOGPJ3cC3vwrIh/8ZupBQbp7BSsqXzr+pTin3aMJ/EZb8UEuk7ZO3VqQFvq2qck/ihc6wqIdw==",
       "dev": true,
       "requires": {
         "decode-uri-component": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "html-webpack-plugin": "^3.2.0",
     "node-sass": "^4.11.0",
     "np": "^4.0.2",
-    "openlaw": "^0.1.19",
+    "openlaw": "^0.1.22",
     "raw-loader": "^1.0.0",
     "react": "^16.8.1",
     "react-dom": "^16.8.1",

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -2,9 +2,11 @@
  * THIS CONFIG FOR OUR EXAMPLE, CONSUMING APP
  */
 
-const HtmlWebpackPlugin = require('html-webpack-plugin')
-const path = require('path')
-const webpack = require('webpack')
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const path = require('path');
+const webpack = require('webpack');
+
+const WARN_APICLIENT = 'OpenLaw APIClient: Please authenticate to the APIClient if you wish to use the Address or Identity inputs.';
 
 module.exports = {
   devtool: 'eval',
@@ -24,7 +26,8 @@ module.exports = {
     new HtmlWebpackPlugin({
       filename: 'index.html',
       inject: true,
-      template: './example/index.html'
+      template: './example/index.html',
+      warningApiClient: !process.env.OPENLAW_EMAIL || !process.env.OPENLAW_PASSWORD ? WARN_APICLIENT : '',
     })
   ],
   module: {


### PR DESCRIPTION
* Bumps openlaw for development
* Adds note to `README` about using the latest `openlaw`
* Adds a clearer "warning" to the top of the example app about logging in to APIClient