### PR TITLE
Adds unique Collection key ids

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,6 +6,7 @@
   ],
   "globals": {
     "document": true,
+    "require": true,
     "setTimeout": true,
     "window": true
   },

--- a/example/index.js
+++ b/example/index.js
@@ -29,7 +29,7 @@ apiClient
   .login(loginDetails.email, loginDetails.password) //eslint-disable-line  no-undef
   .catch((error) => {
     if (/500/.test(error)) {
-      console.warn('OpenLaw APIClient: Please authenticate to the APIClient if you wish to use the Address or Identity inputs.');
+      console.warn('OpenLaw APIClient: Please authenticate to the APIClient if you wish to use the Address input.');
       return;
     }
     console.error('OpenLaw APIClient:', error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -13299,8 +13299,7 @@
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "dev": true
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "v8-compile-cache": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
     "flatpickr": "^4.5.2",
     "prop-types": "^15.7.2",
     "react-autosuggest": "^9.4.3",
-    "react-image-crop": "^6.0.12"
+    "react-image-crop": "^6.0.12",
+    "uuid": "^3.3.2"
   },
   "keywords": [
     "openlaw",

--- a/src/Address.js
+++ b/src/Address.js
@@ -43,17 +43,6 @@ export class Address extends React.PureComponent<Props, State> {
     self.submitAddress = this.submitAddress.bind(this);
   }
 
-  componentDidUpdate(prevProps: Props) {
-    if (
-      this.props.savedValue &&
-      (prevProps.savedValue !== this.props.savedValue)
-    ) {
-      this.setState({
-        currentValue: this.props.savedValue || '',
-      });
-    }
-  }
-
   onChange(event: SyntheticEvent<HTMLInputElement>, autosuggestEvent: Object) {
     const eventValue = event.currentTarget.value;
     const { newValue, method } = autosuggestEvent;

--- a/src/DatePicker.js
+++ b/src/DatePicker.js
@@ -61,19 +61,16 @@ export class DatePicker extends React.PureComponent<Props, State> {
     this.flatpickr = flatpickr(this.flatpickrRef.current, options);
   }
 
-  get isIOS() {
-    return !!window.navigator.platform && /iPad|iPhone|iPod/.test(window.navigator.platform);
-  }
-
-  get shouldShowIOSLabel() {
-    return this.isIOS && !this.props.savedValue;
-  }
-
   onChange(selectedDates: Array<any>) {
     const { name } = this.props;
     const epochUTCString = (selectedDates.length ? selectedDates[0].getTime().toString() : undefined);
 
     this.props.onChange(name, epochUTCString);
+  }
+  
+  shouldShowIOSLabel() {
+    const isIOS = !!window.navigator.platform && /iPad|iPhone|iPod/.test(window.navigator.platform);
+    return isIOS && !this.props.savedValue;
   }
 
   render() {
@@ -93,7 +90,7 @@ export class DatePicker extends React.PureComponent<Props, State> {
           />
         </label>
 
-        {this.shouldShowIOSLabel &&
+        {this.shouldShowIOSLabel() &&
           <span className="ios-label">{description}</span>
         }
       </div>

--- a/src/Identity.js
+++ b/src/Identity.js
@@ -59,29 +59,6 @@ export class Identity extends React.PureComponent<Props, State> {
     }
   }
 
-  componentDidUpdate(prevProps: Props) {
-    const { getValidity, name, openLaw, savedValue } = this.props;
-
-    if (
-      !this.state.validationError
-      && (savedValue !== prevProps.savedValue)
-    ) {
-      try {
-        const identity = getValidity(name, savedValue);
-
-        this.setState({
-          email: openLaw.getIdentityEmail(identity) || '',
-        });
-      }
-      catch (error) {
-        this.setState({
-          email: '',
-          validationError: true,
-        });
-      }
-    }
-  }
-
   onChange(event: SyntheticEvent<HTMLInputElement>) {
     const eventValue = event.currentTarget.value;
     const { apiClient, name, openLaw } = this.props;

--- a/src/LargeText.js
+++ b/src/LargeText.js
@@ -13,13 +13,11 @@ type Props = {
 
 type State = {
   currentValue: string,
-  validationError: boolean,
 };
 
 export class LargeText extends React.PureComponent<Props, State> {
   state = {
     currentValue: this.props.savedValue || '',
-    validationError: false,
   };
 
   constructor(props: Props) {
@@ -29,43 +27,19 @@ export class LargeText extends React.PureComponent<Props, State> {
     self.onChange = this.onChange.bind(this);
   }
 
-  componentDidUpdate(prevProps: Props) {
-    if (
-      !this.state.validationError &&
-      prevProps.savedValue !== this.props.savedValue
-    ) {
-      this.setState({
-        currentValue: this.props.savedValue || '',
-      });
-    }
-  }
-
   onChange(event: SyntheticEvent<*>) {
     const eventValue = event.currentTarget.value;
     const { name } = this.props;
 
-    if (eventValue) {
-      this.setState({
-        currentValue: eventValue,
-        validationError: false,
-      }, () => {
-        this.props.onChange(name, eventValue);
-      });
-    } else {
-      if (this.state.currentValue) {
-        this.setState({
-          currentValue: '',
-          validationError: false,
-        }, () => {
-          this.props.onChange(name);
-        });
-      }
-    }
+    this.setState({
+      currentValue: eventValue,
+    }, () => {
+      this.props.onChange(name, eventValue || undefined);
+    });
   }
 
   render() {
     const { cleanName, description } = this.props;
-    const additionalClassName = this.state.validationError ? ' is-error' : '';
 
     return (
       <div className="contract-variable">
@@ -73,7 +47,7 @@ export class LargeText extends React.PureComponent<Props, State> {
           <span>{description}</span>
 
           <textarea
-            className={`${this.props.textLikeInputClass}${cleanName}${additionalClassName}`}
+            className={`${this.props.textLikeInputClass}${cleanName}`}
             onChange={this.onChange}
             placeholder={description}
             title={description}

--- a/src/NumberInput.js
+++ b/src/NumberInput.js
@@ -31,14 +31,6 @@ export class NumberInput extends React.PureComponent<Props, State> {
     self.onChange = this.onChange.bind(this);
   }
 
-  componentDidUpdate(prevProps: Props) {
-    if (prevProps.savedValue !== this.props.savedValue) {
-      this.setState({
-        currentValue: this.props.savedValue || '',
-      });
-    }
-  }
-
   onChange(event: SyntheticEvent<HTMLInputElement>) {
     const eventValue = event.currentTarget.value;
     const { getValidity, name } = this.props;

--- a/src/Text.js
+++ b/src/Text.js
@@ -31,17 +31,6 @@ export class Text extends React.PureComponent<Props, State> {
     self.onChange = this.onChange.bind(this);
   }
 
-  componentDidUpdate(prevProps: Props) {
-    if (
-      !this.state.validationError &&
-      (this.props.savedValue !== prevProps.savedValue)
-    ) {
-      this.setState({
-        currentValue: this.props.savedValue || '',
-      });
-    }
-  }
-
   onChange(event: SyntheticEvent<HTMLInputElement>) {
     const eventValue = event.currentTarget.value;
     const { getValidity, name } = this.props;

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -6,7 +6,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
 const webpack = require('webpack');
 
-const WARN_APICLIENT = 'OpenLaw APIClient: Please authenticate to the APIClient if you wish to use the Address or Identity inputs.';
+const WARN_APICLIENT = 'OpenLaw APIClient: Please authenticate to the APIClient if you wish to use the Address input.';
 
 module.exports = {
   devtool: 'eval',


### PR DESCRIPTION
Fixes a bug where Collections did not have proper, unique React keys, which really threw React off on updates. Since our Collections do not have unique ids we have to get it done ourselves in the client.

Before, I was using a stop-gap solution of `componentDidUpdate()`, but it also caused a needless re-render. While implementing the web worker in the OpenLaw web app I noticed how the bug can rear its head: 1) It would re-type what I typed as the web worker completed its duties; this was due to `componentDidUpdate()`. 2) When removing said method, React wouldn't know what to do about Collection updates, because there was a lack of unique keys.

