### PR TITLE
removes Identity call to "user/details"

### DIFF
--- a/src/Identity.js
+++ b/src/Identity.js
@@ -3,7 +3,6 @@
 import * as React from 'react';
 
 type Props = {
-  apiClient: Object, // opt-out of type checker until Flow types are exported for APIClient
   cleanName: string,
   description: string,
   getValidity: (string, string) => any | false,
@@ -84,7 +83,7 @@ export class Identity extends React.PureComponent<Props, State> {
 
   onChange(event: SyntheticEvent<HTMLInputElement>) {
     const eventValue = event.currentTarget.value;
-    const { apiClient, name, openLaw } = this.props;
+    const { name, openLaw } = this.props;
 
     try {
       if (!eventValue) {
@@ -108,20 +107,6 @@ export class Identity extends React.PureComponent<Props, State> {
         );
 
         this.isDataValid = true;
-
-        apiClient.getUserDetails(eventValue).then(result => {
-          if (result.email) {
-            this.props.onChange(
-              name,
-              openLaw.createIdentityInternalValue(result.id, result.email),
-            );
-
-            this.setState({
-              email: result.email,
-              validationError: false,
-            });
-          }
-        });
       }
     } catch (error) {
       this.isDataValid = false;

--- a/src/InputRenderer.js
+++ b/src/InputRenderer.js
@@ -137,7 +137,6 @@ export const InputRenderer = (props: RendererProps) => {
     case 'Identity':
       return (
         <Identity
-          apiClient={apiClient}
           cleanName={cleanName}
           description={description}
           getValidity={attemptCheckValidity}


### PR DESCRIPTION
Fixes #53 

Removes dead code from Identity variable as no method exists upstream in OpenLaw instances, anymore.

Validation will be handled in the client.