### PR TITLE
Fixes Image input validation

### DIFF
--- a/src/ImageInput.js
+++ b/src/ImageInput.js
@@ -212,7 +212,7 @@ export class ImageInput extends React.PureComponent<Props, State> {
     this.setState({ showModal: !(this.state.showModal) });
   }
 
-  resizeImageSource(dataURL: string): Promise<any> {
+  resizeImageSource(dataURL: string): Promise<string> {
     return new Promise((resolve, reject) => {
       if (!dataURL) {
         reject('');
@@ -256,10 +256,8 @@ export class ImageInput extends React.PureComponent<Props, State> {
       resizedImageDataURL = '';
     }
 
-    const validity = getValidity(name, resizedImageDataURL);
-
-    // if the valid string either has length, or is empty, it's valid
-    const isImageDataValid = (validity && validity.length > 0) || (validity === '' && validity.length === 0);
+    // if the valid string either has length, or is empty, it will be valid
+    const isImageDataValid = getValidity(name, resizedImageDataURL) && typeof resizedImageDataURL === 'string';
 
     if (isImageDataValid) {
       if (resizedImageDataURL) {


### PR DESCRIPTION
A recent change in OpenLaw Core does not throw an error if the data provided to [`checkValidity`](https://docs.openlaw.io/openlaw-object/#checkvalidity) is not a String.

The issue does not affect the `ImageInput` adversely, since it's a `string` that has already been vetted by other functions to output a data URL, before `checkValidity` is called. So, we can work around it.