### PR TITLE
Image adds "undefined" to match other inputs on empty

### DIFF
--- a/src/ImageInput.js
+++ b/src/ImageInput.js
@@ -9,7 +9,7 @@ type Props = {
   description: string,
   getValidity: (string, string) => string | false,
   name: string,
-  onChange: (string, string) => mixed,
+  onChange: (string, ?string) => mixed,
   savedValue: string,
 };
 
@@ -269,7 +269,7 @@ export class ImageInput extends React.PureComponent<Props, State> {
           this.props.onChange(name, resizedImageDataURL);
         });
       } else {
-        this.props.onChange(name, '');
+        this.props.onChange(name);
       }
     } else {
       this.setState({


### PR DESCRIPTION
Image needs to match other inputs values on empty: `undefined`. It works but is not predictable.