### PR TITLE
Fixes DatePicker not responding to props changes

### DIFF
--- a/example/SAMPLE_TEMPLATE.js
+++ b/example/SAMPLE_TEMPLATE.js
@@ -26,7 +26,7 @@ export default `<%
 [[MedicalContact: Contestant Emergency Contact]]
 %>
 
-\centered **International BBQ Cookoff Registration**
+\\centered **International BBQ Cookoff Registration**
 
 [[Contestant Name "Your Name"]]
 [[Contestant Address: Address "Mailing Address"]]

--- a/src/DatePicker.js
+++ b/src/DatePicker.js
@@ -89,7 +89,7 @@ export class DatePicker extends React.PureComponent<Props, State> {
           <span>{description}</span>
 
           {/* flatpickr-enabled input */}
-          {/* options are handled in componentDidMount */}
+          {/* options are handled in this.getFlatpickrOptions */}
           <input
             placeholder={description}
             


### PR DESCRIPTION
Type `Date` was not responding to props changes. 
e.g. `inputProps: { '*': { disabled: true } }` then toggle `true`.

The issue I believe is the way Flatpickr instantiates itself in a React component.

Successfully reproduced inside a test and inside the example app.

**Other**
- Adds new test to prove fix is working
- Cleans up tests a bit
- Fixes escaping for `SAMPLE_AGREEMENT.txt`: `/centered`
- Refactors `Date` Flatpickr props a bit.



