### PR TITLE
Fixes bug where Text was providing an empty string instead of undefined

### DIFF
--- a/src/Text.js
+++ b/src/Text.js
@@ -94,7 +94,9 @@ export class Text extends React.PureComponent<Props, State> {
       errorMessage: errorData.errorMessage,
       shouldShowError,
     }, () => {
-      const shouldValueBeUndefined = variableType !== TEXT && (errorData.isError || eventValue === '');
+      const shouldValueBeUndefined = variableType !== TEXT && (errorData.isError || eventValue === '')
+        ? true
+        : variableType === TEXT && eventValue === '';
 
       onChange(
         name,

--- a/src/__tests__/Text.test.js
+++ b/src/__tests__/Text.test.js
@@ -150,6 +150,36 @@ test('Can call onChangeFunction', () => {
   expect(changeSpy.mock.calls[0][1]).toMatch(/morgan smith/i);
 });
 
+test('Can call onChangeFunction with `undefined` value if empty string', () => {
+  const changeSpy = jest.fn();
+
+  const { getByPlaceholderText } = render(
+    <TestOpenLawFormComponent
+      onChangeFunction={changeSpy}
+    />
+  );
+
+  fireEvent.change(
+    getByPlaceholderText(/contestant name/i),
+    { target: { value: 'Morgan Smith' } },
+  );
+  fireEvent.blur(getByPlaceholderText(/contestant name/i));
+
+  expect(changeSpy.mock.calls.length).toBe(1);
+  expect(changeSpy.mock.calls[0][0]).toMatch(/contestant name/i);
+  expect(changeSpy.mock.calls[0][1]).toMatch(/morgan smith/i);
+
+  fireEvent.change(
+    getByPlaceholderText(/contestant name/i),
+    { target: { value: '' } },
+  );
+  fireEvent.blur(getByPlaceholderText(/contestant name/i));
+
+  expect(changeSpy.mock.calls.length).toBe(2);
+  expect(changeSpy.mock.calls[1][0]).toMatch(/contestant name/i);
+  expect(changeSpy.mock.calls[1][1]).toBeUndefined();
+});
+
 test('Can call inputProps: onChange, onBlur', () => {
   const changeSpy = jest.fn();
   const blurSpy = jest.fn();


### PR DESCRIPTION
First noticed in https://github.com/openlawteam/openlaw-app/issues/2769

* If a `<Text />` input is blank, returns a `undefined`, not an empty string
* Test added