### PR TITLE
style changes for image base styles; Fragment for wrapping ImageCrop

### DIFF
--- a/src/ImageCrop.js
+++ b/src/ImageCrop.js
@@ -52,7 +52,7 @@ type StateTypes = {
   src: string,
 };
 
-const { Component } = React;
+const { Component, Fragment } = React;
 
 const styles = {
   cropWrap: {
@@ -321,7 +321,7 @@ export default class ImageCrop extends Component<PropTypes, StateTypes> {
 
   render() {
     return (
-      <div>
+      <Fragment>
         {this.props.children ? (
           this.props.children({
             Crop: this.renderReactComp,
@@ -332,7 +332,7 @@ export default class ImageCrop extends Component<PropTypes, StateTypes> {
         ) : (
           this.renderReactComp(this.getReactCropProps())
         )}
-      </div>
+      </Fragment>
     );
   }
 }

--- a/src/style.scss
+++ b/src/style.scss
@@ -244,11 +244,8 @@ $text-input-height: 2.25rem;
 }
 
 .#{$NAMESPACE}-field-image__editor {
-  align-items: center;
   border-radius: .375rem;
   border: 1px solid #d8d8d8;
-  display: flex;
-  flex-direction: column;
   margin: .375rem 0;
   padding: 1.2rem;
 }
@@ -257,7 +254,7 @@ $text-input-height: 2.25rem;
   @extend %flex-row-split;
   align-items: center;
   flex-direction: row-reverse;
-  margin-top: .375rem;
+  margin: 1rem auto .375rem;
   width: 10rem;
 }
 


### PR DESCRIPTION
* Fixed a bug in the base styles for the image editor where it would not provide any available space to fill.
* Removes empty `<div>` container around `ImageCrop` and replaces with a `<Fragment>`