### PR TITLE
Adds OPENLAW_INSTANCE_NAME to example and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ OPENLAW_EMAIL=alex@email.com OPENLAW_PASSWORD=password npm start
 * Select an Address lookup from the drop-down
 * See those values in the rendered preview HTML
 
+#### Authenticating against your own instance
+
+If you would like to use your own [OpenLaw Private Instance](https://docs.openlaw.io/private-self-hosted-instances/#private-instances) to authenticate against, provide the `OPENLAW_INSTANCE_NAME` environment variable.
+
+```
+OPENLAW_INSTANCE_NAME="cool" OPENLAW_EMAIL=alex@email.com OPENLAW_PASSWORD=password npm start
+```
+
 ### About the app
 
 The example app (`openlaw-elements/example`) can help you gain ideas and understanding to build your own OpenLaw app in JavaScript and React. In contrast to the example app, the "Usage" section above intentionally leaves out more complex behavior to simply illustrate the required dependencies in order to use `<OpenLawForm />` correctly.

--- a/example/auth.js
+++ b/example/auth.js
@@ -2,15 +2,17 @@
 
 import { APIClient } from 'openlaw';
 
-// For logging into your OpenLaw instance: 'https://[YOUR.INSTANCE.URL]';
-const INSTANCE_URL = 'https://develop.dev.openlaw.io';
+const { OPENLAW_EMAIL, OPENLAW_INSTANCE_NAME, OPENLAW_PASSWORD } = process.env;
+
+// Provide your OPENLAW_INSTANCE_NAME for logging into your OpenLaw instance.
+const INSTANCE_URL = `https://lib.openlaw.io/api/v1/${OPENLAW_INSTANCE_NAME.toLowerCase() || 'default'}`;
 
 export const apiClientSingleton = new APIClient(INSTANCE_URL);
 
 export const attemptAuth = () => {
   const loginDetails = {
-    email: process.env.OPENLAW_EMAIL || '',
-    password: process.env.OPENLAW_PASSWORD || '',
+    email: OPENLAW_EMAIL || '',
+    password: OPENLAW_PASSWORD || '',
   };
 
   apiClientSingleton

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -21,6 +21,7 @@ module.exports = {
   plugins: [
     new webpack.DefinePlugin({
       'process.env.OPENLAW_EMAIL': JSON.stringify(process.env.OPENLAW_EMAIL),
+      'process.env.OPENLAW_INSTANCE_NAME': JSON.stringify(process.env.OPENLAW_INSTANCE_NAME),
       'process.env.OPENLAW_PASSWORD': JSON.stringify(process.env.OPENLAW_PASSWORD),
     }),
     new HtmlWebpackPlugin({


### PR DESCRIPTION
When running the example app the `OPENLAW_INSTANCE_NAME` env var allows a user of the example app to authenticate against their own OpenLaw instance.

**Usage**

`OPENLAW_INSTANCE_NAME="cool" OPENLAW_EMAIL=alex@email.com OPENLAW_PASSWORD=password npm start`